### PR TITLE
Add switch, table.map, table.filter, and table.contains into scripting lua

### DIFF
--- a/plugin_files/bin/scripting/utils.lua
+++ b/plugin_files/bin/scripting/utils.lua
@@ -134,3 +134,61 @@ end
 string.trim = function(str)
     return (str:gsub("^%s*(.-)%s*$", "%1"))
 end
+
+
+--- @param value any The value to be matched against. Can be a number or a string.
+--- @param cases table
+--- @return any Returns
+switch = function(value, cases)
+    local case = cases[value]
+    if case then
+        if type(case) == "function" then
+            return case()
+        else
+            return case
+        end
+    elseif cases.default then
+        if type(cases.default) == "function" then
+            return cases.default()
+        else
+            return cases.default
+        end
+    end
+end
+
+--- @param tbl table The table to be mapped.
+--- @param func function A function that takes a value and key as parameters and returns a new value.
+--- @return table A new table with the transformed values.
+table.map = function(tbl, func)
+    local result = {}
+    for key, value in next, tbl do
+        result[key] = func(value, key)
+    end
+    return result
+end
+
+--- @param tbl table The table to be filtered.
+--- @param predicate function A function that takes a value and key as parameters and returns a boolean.
+--- @return table A new table containing only the elements for which the predicate returned true.
+table.filter = function(tbl, predicate)
+    local result = {}
+    local index = 1
+    for key, value in next, tbl do
+        if predicate(value, key) then
+            result[index] = value
+            index = index + 1
+        end
+    end
+    return result
+end
+--- @param tbl table The table to search.
+--- @param value any The value to search for.
+--- @return boolean True if the value exists in the table, false otherwise.
+table.contains = function(tbl, value)
+    for _, val in next, tbl do
+        if val == value then
+            return true
+        end
+    end
+    return false
+end


### PR DESCRIPTION
### Add `switch`, `table.map`, `table.filter`, and `table.contains` Functions in `utils.lua`

**Description:**

This PR adds four utility functions to the `bin/scripting/utils.lua` file:

1. **`switch` function**: 
   - Allows for a switch-like behavior in Lua, matching a value against a set of cases.
   - It supports functions or direct values for each case and includes a default fallback.
   - Example:
     ```lua
     local result = switch("hello", {
         hello = function() return "world" end,
         goodbye = "farewell",
         default = function() return "unknown" end
     })
     print(result) -- Output: world
     ```

2. **`table.map` function**:
   - Maps a given function to each element in a table, returning a new table with the transformed values.
   - Example:
     ```lua
     local numbers = {1, 2, 3}
     local doubled = table.map(numbers, function(value)
         return value * 2
     end)
     print(table.concat(doubled, ", ")) -- Output: 2, 4, 6
     ```

3. **`table.filter` function**:
   - Filters elements of a table based on a provided predicate function, returning a new table with elements that satisfy the condition.
   - Example:
     ```lua
     local numbers = {1, 2, 3, 4, 5}
     local evenNumbers = table.filter(numbers, function(value)
         return value % 2 == 0
     end)
     print(table.concat(evenNumbers, ", ")) -- Output: 2, 4
     ```

4. **`table.contains` function**:
   - Checks if a table contains a specific value.
   - Example:
     ```lua
     local colors = {"red", "green", "blue"}
     local hasRed = table.contains(colors, "red")
     print(hasRed) -- Output: true
     ```

These utility functions will simplify common operations when working with tables in Lua, improving code readability and maintainability.