### PR TITLE
refactor(print): replace fprintf with META_CONPRINT.

### DIFF
--- a/src/plugins/lua/scripting/core.cpp
+++ b/src/plugins/lua/scripting/core.cpp
@@ -9,7 +9,7 @@ std::vector<LuaLoader*> luaLoaderClasses;
 
 int customPrint(lua_State* state)
 {
-    std::string prefix = string_format("[Swiftly] %s[%16s]\e[39m ", GetTerminalStringColor(FetchPluginName(state)).c_str(), ("plugin:" + FetchPluginName(state)).c_str());
+    std::string prefix = string_format("[Swiftly] %s[%s]\e[39m ", GetTerminalStringColor(FetchPluginName(state)).c_str(), ("plugin:" + FetchPluginName(state)).c_str());
 
     int n = lua_gettop(state);
 
@@ -44,7 +44,7 @@ int customPrint(lua_State* state)
             continue;
 
         std::string final_string = string_format("%s%s\e[39m\e[49m\n", prefix.c_str(), str.c_str());
-        fprintf(stdout, final_string.c_str());
+        META_CONPRINT(final_string.c_str());
     }
 
     return 0;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -187,7 +187,7 @@ bool starts_with(std::string value, std::string starting)
 void PLUGIN_PRINT(std::string category, std::string str)
 {
     std::string final_string = string_format("%s %s[%s]%s %s", PREFIX, GetTerminalStringColor(category).c_str(), category.c_str(), terminalColors.at("{DEFAULT}").c_str(), str.c_str());
-    fprintf(stdout, final_string.c_str());
+    META_CONPRINT(final_string.c_str());
 
     if (g_Config && g_Config->FetchValue<bool>("core.logging.save_core_messages")) {
         if (g_Logger && g_Logger->FetchLogger("core")) {
@@ -207,7 +207,7 @@ void PLUGIN_PRINTF(std::string category, std::string str, ...)
     va_end(ap);
 
     std::string final_string = string_format("%s %s[%s]%s %s", PREFIX, GetTerminalStringColor(category).c_str(), category.c_str(), terminalColors.at("{DEFAULT}").c_str(), buffer);
-    fprintf(stdout, final_string.c_str());
+    META_CONPRINT(final_string.c_str());
 
     if (g_Config && g_Config->FetchValue<bool>("core.logging.save_core_messages")) {
         if (g_Logger && g_Logger->FetchLogger("core")) {


### PR DESCRIPTION
**Reason:** _External RCON tools returned an empty string, requiring a change to ensure proper output compatibility._ 