### PR TITLE
New soundevent emitter

### DIFF
--- a/generators/gamesdkdocumentation/cs2/docs/classes/cbaseentity.json
+++ b/generators/gamesdkdocumentation/cs2/docs/classes/cbaseentity.json
@@ -403,7 +403,7 @@
                 "pitch": "float",
                 "volume": "float"
             },
-            "return": "void"
+            "return": "int"
         },
         {
             "name": "EmitSoundFromEntity",
@@ -413,7 +413,7 @@
                 "volume": "float",
                 "delay": "float"
             },
-            "return": "void"
+            "return": "int"
         },
         {
             "name": "TakeDamage",

--- a/generators/gamesdkdocumentation/cs2/docs/classes/cbaseentity.json
+++ b/generators/gamesdkdocumentation/cs2/docs/classes/cbaseentity.json
@@ -403,7 +403,7 @@
                 "pitch": "float",
                 "volume": "float"
             },
-            "return": "int"
+            "return": "uint32"
         },
         {
             "name": "EmitSoundFromEntity",
@@ -413,7 +413,7 @@
                 "volume": "float",
                 "delay": "float"
             },
-            "return": "int"
+            "return": "uint32"
         },
         {
             "name": "TakeDamage",

--- a/plugin_files/configs/core.example.json
+++ b/plugin_files/configs/core.example.json
@@ -13,7 +13,7 @@
     "console_filtering": true,
     "language": "en",
     "use_player_language": true,
-    "patches_to_perform": ["EmitSoundVolumePatch"],
+    "patches_to_perform": [],
     "CS2ServerGuidelines": "https://blog.counter-strike.net/index.php/server_guidelines/",
     "FollowCS2ServerGuidelines": true,
     "menu": {

--- a/plugin_files/gamedata/cs2/core/offsets.json
+++ b/plugin_files/gamedata/cs2/core/offsets.json
@@ -38,5 +38,9 @@
     "CEntityResourceManifest_AddResource": {
         "windows": 2,
         "linux": 0
+    },
+    "CSoundSystem_TakeGuid": {
+        "windows": 72,
+        "linux": 71
     }
 }

--- a/protobufs/cs2/gameevents.proto
+++ b/protobufs/cs2/gameevents.proto
@@ -1,0 +1,120 @@
+import "networkbasetypes.proto";
+
+enum EBaseGameEvents {
+	GE_VDebugGameSessionIDEvent = 200;
+	GE_PlaceDecalEvent = 201;
+	GE_ClearWorldDecalsEvent = 202;
+	GE_ClearEntityDecalsEvent = 203;
+	GE_ClearDecalsForSkeletonInstanceEvent = 204;
+	GE_Source1LegacyGameEventList = 205;
+	GE_Source1LegacyListenEvents = 206;
+	GE_Source1LegacyGameEvent = 207;
+	GE_SosStartSoundEvent = 208;
+	GE_SosStopSoundEvent = 209;
+	GE_SosSetSoundEventParams = 210;
+	GE_SosSetLibraryStackFields = 211;
+	GE_SosStopSoundEventHash = 212;
+}
+
+message CMsgVDebugGameSessionIDEvent {
+	optional int32 clientid = 1;
+	optional string gamesessionid = 2;
+}
+
+message CMsgPlaceDecalEvent {
+	optional .CMsgVector position = 1;
+	optional .CMsgVector normal = 2;
+	optional .CMsgVector saxis = 3;
+	optional uint32 decalmaterialindex = 4;
+	optional uint32 flags = 5;
+	optional fixed32 color = 6;
+	optional float width = 7;
+	optional float height = 8;
+	optional float depth = 9;
+	optional uint32 entityhandleindex = 10;
+	optional fixed32 skeletoninstancehash = 11;
+	optional int32 boneindex = 12;
+	optional bool translucenthit = 13;
+	optional bool is_adjacent = 14;
+}
+
+message CMsgClearWorldDecalsEvent {
+	optional uint32 flagstoclear = 1;
+}
+
+message CMsgClearEntityDecalsEvent {
+	optional uint32 flagstoclear = 1;
+}
+
+message CMsgClearDecalsForSkeletonInstanceEvent {
+	optional uint32 flagstoclear = 1;
+	optional uint32 entityhandleindex = 2;
+	optional uint32 skeletoninstancehash = 3;
+}
+
+message CMsgSource1LegacyGameEventList {
+	message key_t {
+		optional int32 type = 1;
+		optional string name = 2;
+	}
+
+	message descriptor_t {
+		optional int32 eventid = 1;
+		optional string name = 2;
+		repeated .CMsgSource1LegacyGameEventList.key_t keys = 3;
+	}
+
+	repeated .CMsgSource1LegacyGameEventList.descriptor_t descriptors = 1;
+}
+
+message CMsgSource1LegacyListenEvents {
+	optional int32 playerslot = 1;
+	repeated uint32 eventarraybits = 2;
+}
+
+message CMsgSource1LegacyGameEvent {
+	message key_t {
+		optional int32 type = 1;
+		optional string val_string = 2;
+		optional float val_float = 3;
+		optional int32 val_long = 4;
+		optional int32 val_short = 5;
+		optional int32 val_byte = 6;
+		optional bool val_bool = 7;
+		optional uint64 val_uint64 = 8;
+	}
+
+	optional string event_name = 1;
+	optional int32 eventid = 2;
+	repeated .CMsgSource1LegacyGameEvent.key_t keys = 3;
+	optional int32 server_tick = 4;
+	optional int32 passthrough = 5;
+}
+
+message CMsgSosStartSoundEvent {
+	optional int32 soundevent_guid = 1;
+	optional fixed32 soundevent_hash = 2;
+	optional int32 source_entity_index = 3 [default = -1];
+	optional int32 seed = 4;
+	optional bytes packed_params = 5;
+	optional float start_time = 6;
+}
+
+message CMsgSosStopSoundEvent {
+	optional int32 soundevent_guid = 1;
+}
+
+message CMsgSosStopSoundEventHash {
+	optional fixed32 soundevent_hash = 1;
+	optional int32 source_entity_index = 2 [default = -1];
+}
+
+message CMsgSosSetSoundEventParams {
+	optional int32 soundevent_guid = 1;
+	optional bytes packed_params = 5;
+}
+
+message CMsgSosSetLibraryStackFields {
+	optional fixed32 stack_hash = 1;
+	optional bytes packed_fields = 5;
+}

--- a/src/core/entrypoint.cpp
+++ b/src/core/entrypoint.cpp
@@ -161,6 +161,7 @@ bool SwiftlyS2::Load(PluginId id, ISmmAPI* ismm, char* error, size_t maxlen, boo
     GET_V_IFACE_ANY(GetEngineFactory, g_pNetworkMessages, INetworkMessages, NETWORKMESSAGES_INTERFACE_VERSION);
     GET_V_IFACE_ANY(GetServerFactory, g_pSource2GameEntities, ISource2GameEntities, SOURCE2GAMEENTITIES_INTERFACE_VERSION);
     GET_V_IFACE_ANY(GetEngineFactory, g_pNetworkServerService, INetworkServerService, NETWORKSERVERSERVICE_INTERFACE_VERSION);
+    GET_V_IFACE_ANY(GetEngineFactory, g_pSoundSystem, ISoundSystem, SOUNDSYSTEM_INTERFACE_VERSION);
 
     SH_ADD_HOOK_MEMFUNC(IServerGameDLL, GameServerSteamAPIActivated, server, this, &SwiftlyS2::Hook_GameServerSteamAPIActivated, false);
     SH_ADD_HOOK_MEMFUNC(IServerGameDLL, GameServerSteamAPIDeactivated, server, this, &SwiftlyS2::Hook_GameServerSteamAPIDeactivated, false);

--- a/src/network/soundevents/soundevent.cpp
+++ b/src/network/soundevents/soundevent.cpp
@@ -1,0 +1,115 @@
+#include "soundevent.h"
+
+#include <public/const.h>
+#include <public/bitvec.h>
+#include <public/steam/steamtypes.h>
+
+#define GETCHECK_FIELD(return_value)								\
+	SosField* field = this->GetField(pszFieldName);					\
+	if (field == nullptr)											\
+		return return_value;
+
+#define CHECK_FIELD_TYPE(check_type, return_value)					\
+    if (field->type != check_type) return return_value;
+
+#define SET_FIELD(check_type, value)								\
+	SosField field;													\
+	field.type = check_type;										\
+	field.data = value;												\
+	this->AddOrReplaceField(pszFieldName, &field);
+
+void Soundevent::SetName(std::string name) 
+{
+	this->name = name;
+}
+
+std::string Soundevent::GetName() 
+{
+	return this->name;
+}
+
+void Soundevent::SetSourceEntityIndex(int sourceEntityIndex) 
+{
+	this->sourceEntityIndex = sourceEntityIndex;
+}
+
+int Soundevent::GetSourceEntityIndex() 
+{
+	return this->sourceEntityIndex;
+}
+
+void Soundevent::AddClient(int playerid) 
+{
+	this->clients.Set(playerid);
+}
+
+void Soundevent::RemoveClient(int playerid) 
+{
+	this->clients.Clear(playerid);
+}
+
+void Soundevent::ClearClients() 
+{
+	this->clients.ClearAll();
+}
+
+void Soundevent::AddClients() 
+{
+	this->clients.SetAll();
+}
+
+std::vector<int> Soundevent::GetClients()
+{
+	std::vector<int> clns;
+	if (this->clients.IsAllClear()) return clns;
+
+	for (int i = 0; i < 64; i++)
+		if (this->clients.IsBitSet(i))
+            clns.push_back(i);
+
+	return clns;
+}
+
+SosField* Soundevent::GetField(std::string pszFieldName)
+{
+	auto it = this->parameters.find(pszFieldName);
+    return (it != this->parameters.end()) ? &it->second : nullptr;
+}
+
+void Soundevent::AddOrReplaceField(std::string pszFieldName, const SosField* field)
+{
+	this->parameters[pszFieldName] = *field;
+}
+
+bool Soundevent::HasField(std::string pszFieldName)
+{
+	return this->GetField(pszFieldName) != nullptr;
+}
+
+void Soundevent::SetBool(std::string pszFieldName, bool value)
+{
+	CVariant data(value);
+	SET_FIELD(SE_Bool, data);
+}
+
+bool Soundevent::GetBool(std::string pszFieldName)
+{
+	GETCHECK_FIELD(false);
+	CHECK_FIELD_TYPE(SE_Bool, false);
+
+	return field->data.Get<bool>();
+}
+
+void Soundevent::SetInt(std::string pszFieldName, int value)
+{
+	CVariant data(value);
+	SET_FIELD(SE_Int, (int32)data);
+}
+
+int Soundevent::GetInt(std::string pszFieldName)
+{
+	GETCHECK_FIELD(0);
+	CHECK_FIELD_TYPE(SE_Int, 0);
+
+	return (int)field->data.Get<int32>();
+}

--- a/src/network/soundevents/soundevent.cpp
+++ b/src/network/soundevents/soundevent.cpp
@@ -39,7 +39,7 @@ void insert(std::vector<uint8_t>& vec, const T* value, int size = -1) {
     }
 }
 
-int Soundevent::Emit()
+uint32_t Soundevent::Emit()
 {
 	// packed_param serialization
 	std::vector<uint8_t> buffer;

--- a/src/network/soundevents/soundevent.cpp
+++ b/src/network/soundevents/soundevent.cpp
@@ -92,6 +92,7 @@ int Soundevent::Emit()
 	data->set_soundevent_hash(soundeventHash);
 	data->set_source_entity_index(this->sourceEntityIndex);
 	data->set_soundevent_guid(guid);
+	data->set_seed(guid);
 	data->set_packed_params(std::string(buffer.begin(), buffer.end()));
 	
 	g_pGameEventSystem->PostEventAbstract(-1, false, &this->clients, pNetMsg, data, 0);
@@ -101,6 +102,7 @@ int Soundevent::Emit()
 
 Soundevent::Soundevent()
 {
+	this->clients = CRecipientFilter();
 }
 
 void Soundevent::SetName(std::string name) 
@@ -121,6 +123,11 @@ void Soundevent::SetSourceEntityIndex(int sourceEntityIndex)
 int Soundevent::GetSourceEntityIndex() 
 {
 	return this->sourceEntityIndex;
+}
+
+void Soundevent::SetRecipientFilter(CRecipientFilter filter)
+{
+	this->clients = filter;
 }
 
 void Soundevent::AddClient(int playerid) 

--- a/src/network/soundevents/soundevent.cpp
+++ b/src/network/soundevents/soundevent.cpp
@@ -1,8 +1,20 @@
 #include "soundevent.h"
 
-#include <public/const.h>
-#include <public/bitvec.h>
+#include <iomanip>
+
+#include <core/entrypoint.h>
+#include <memory/gamedata/gamedata.h>
+#include <memory/virtual/virtual.h>
+#include <sdk/components/CSingleRecipientFilter.h>
+
+#include <public/networksystem/netmessage.h>
+#include <public/tier1/generichash.h>
 #include <public/steam/steamtypes.h>
+#include <public/mathlib/vector.h>
+#include <public/entity2/entitysystem.h>
+#include <public/entity2/entityidentity.h>
+
+#include <gameevents.pb.h>
 
 #define GETCHECK_FIELD(return_value)								\
 	SosField* field = this->GetField(pszFieldName);					\
@@ -17,6 +29,79 @@
 	field.type = check_type;										\
 	field.data = value;												\
 	this->AddOrReplaceField(pszFieldName, &field);
+
+template<typename T>
+void insert(std::vector<uint8_t>& vec, const T* value, int size = -1) {
+    const char* bytes = reinterpret_cast<const char*>(value);
+    
+    for (size_t i = 0; i < (size == -1 ? sizeof(T) : size); ++i) {
+        vec.push_back(bytes[i]);
+    }
+}
+
+int Soundevent::Emit()
+{
+	// packed_param serialization
+	std::vector<uint8_t> buffer;
+	for (const auto& pair : this->parameters) {
+		auto fieldName = pair.first;
+		auto fieldData = &pair.second;
+		auto data = &fieldData->data;
+		uint32_t paramNameHash = MurmurHash2LowerCase(fieldName.c_str(), SOUNDEVENT_FIELD_NAME_HASH_SEED);
+		insert(buffer, &paramNameHash);										// name hash
+		buffer.push_back(fieldData->type);									// data type
+
+		char size;
+		switch (fieldData->type) {
+			case SE_Bool:
+				buffer.push_back(1);										// data size
+				buffer.push_back(0);										// padding
+				buffer.push_back(data->m_bool);								// data
+				break;
+			case SE_Int:
+			case SE_UInt32:
+			case SE_Float:
+				buffer.push_back(4);
+				buffer.push_back(0);
+				insert(buffer, data, 4);	// insert in little endian order
+				break;
+			case SE_UInt64:
+				buffer.push_back(8);
+				buffer.push_back(0);
+				insert(buffer, data, 8);
+				break;
+			case SE_Float3:
+				buffer.push_back(12);
+				buffer.push_back(0);
+				insert(buffer, data->m_pVector, 12);
+				break;
+		}
+	}
+
+	auto soundeventHash = MurmurHash2LowerCase(this->name.c_str(), SOUNDEVENT_NAME_HASH_SEED);
+	INetworkMessageInternal* pNetMsg = g_pNetworkMessages->FindNetworkMessageById(208);
+    auto data = pNetMsg->AllocateMessage()->ToPB<CMsgSosStartSoundEvent>();
+
+	uint32_t guid;
+#ifdef _WIN32
+	CALL_VIRTUAL(void, g_GameData.GetOffset("CSoundSystem_TakeGuid"), g_pSoundSystem, &guid);
+#else
+	guid = CALL_VIRTUAL(uint32_t, g_GameData.GetOffset("CSoundSystem_TakeGuid"), g_pSoundSystem);
+#endif
+
+	data->set_soundevent_hash(soundeventHash);
+	data->set_source_entity_index(this->sourceEntityIndex);
+	data->set_soundevent_guid(guid);
+	data->set_packed_params(std::string(buffer.begin(), buffer.end()));
+	
+	g_pGameEventSystem->PostEventAbstract(-1, false, &this->clients, pNetMsg, data, 0);
+
+	return guid;
+}
+
+Soundevent::Soundevent()
+{
+}
 
 void Soundevent::SetName(std::string name) 
 {
@@ -40,31 +125,32 @@ int Soundevent::GetSourceEntityIndex()
 
 void Soundevent::AddClient(int playerid) 
 {
-	this->clients.Set(playerid);
+	this->clients.AddRecipient(CPlayerSlot(playerid));
 }
 
 void Soundevent::RemoveClient(int playerid) 
 {
-	this->clients.Clear(playerid);
+	this->clients.RemoveRecipient(CPlayerSlot(playerid));
 }
 
 void Soundevent::ClearClients() 
 {
-	this->clients.ClearAll();
+	this->clients.RemoveAllPlayers();
 }
 
 void Soundevent::AddClients() 
 {
-	this->clients.SetAll();
+	this->clients.AddAllPlayers();
 }
 
 std::vector<int> Soundevent::GetClients()
 {
 	std::vector<int> clns;
-	if (this->clients.IsAllClear()) return clns;
+	auto recipients = this->clients.GetRecipients();
+	if (this->clients.GetRecipientCount() == 0) return clns;
 
 	for (int i = 0; i < 64; i++)
-		if (this->clients.IsBitSet(i))
+		if (recipients.IsBitSet(i))
             clns.push_back(i);
 
 	return clns;
@@ -102,8 +188,8 @@ bool Soundevent::GetBool(std::string pszFieldName)
 
 void Soundevent::SetInt(std::string pszFieldName, int value)
 {
-	CVariant data(value);
-	SET_FIELD(SE_Int, (int32)data);
+	CVariant data((int32)value);
+	SET_FIELD(SE_Int, data);
 }
 
 int Soundevent::GetInt(std::string pszFieldName)
@@ -112,4 +198,61 @@ int Soundevent::GetInt(std::string pszFieldName)
 	CHECK_FIELD_TYPE(SE_Int, 0);
 
 	return (int)field->data.Get<int32>();
+}
+
+void Soundevent::SetUInt32(std::string pszFieldName, uint32_t value)
+{
+	CVariant data((uint32)value);
+	SET_FIELD(SE_UInt32, data);
+}
+
+uint32_t Soundevent::GetUInt32(std::string pszFieldName)
+{
+	GETCHECK_FIELD(0);
+	CHECK_FIELD_TYPE(SE_UInt32, 0);
+
+	return (uint32_t)field->data.Get<uint32>();
+}
+
+void Soundevent::SetUInt64(std::string pszFieldName, uint64_t value)
+{
+	CVariant data((uint64)value);
+	SET_FIELD(SE_UInt64, data);
+}
+
+uint64_t Soundevent::GetUInt64(std::string pszFieldName)
+{
+	GETCHECK_FIELD(0);
+	CHECK_FIELD_TYPE(SE_UInt64, 0);
+
+	return (uint64_t)field->data.Get<uint64>();
+}
+
+void Soundevent::SetFloat(std::string pszFieldName, float value)
+{
+	CVariant data(value);
+	SET_FIELD(SE_Float, data);
+}
+
+float Soundevent::GetFloat(std::string pszFieldName)
+{
+	GETCHECK_FIELD(0.0f);
+	CHECK_FIELD_TYPE(SE_Float, 0.0f);
+
+	return field->data.Get<float>();
+}
+
+void Soundevent::SetFloat3(std::string pszFieldName, Vector& value)
+{
+	CVariant data(value);
+	SET_FIELD(SE_Float3, data);
+}
+
+Vector Soundevent::GetFloat3(std::string pszFieldName)
+{
+	Vector def;
+	GETCHECK_FIELD(def);
+	CHECK_FIELD_TYPE(SE_Float3, def);
+
+	return field->data.Get<Vector>();
 }

--- a/src/network/soundevents/soundevent.h
+++ b/src/network/soundevents/soundevent.h
@@ -49,6 +49,7 @@ public:
 	void SetSourceEntityIndex(int sourceEntityIndex);
 	int GetSourceEntityIndex();
 
+	void SetRecipientFilter(CRecipientFilter filter);
 	void AddClient(int playerid);
 	void RemoveClient(int playerId);
     void ClearClients();

--- a/src/network/soundevents/soundevent.h
+++ b/src/network/soundevents/soundevent.h
@@ -7,9 +7,10 @@
 #include <variant.h>
 #include <public/bitvec.h>
 #include <mathlib/vector.h>
+#include <sdk/components/CSingleRecipientFilter.h>
 
-#define SOUNDEVENT_NAME_HASH 0x53524332
-#define SOUNDEVENT_PARAM_NAME_HASH 0x31415926
+#define SOUNDEVENT_NAME_HASH_SEED 0x53524332
+#define SOUNDEVENT_FIELD_NAME_HASH_SEED 0x31415926
 /*
 reversed from game, there's more type than the following,
 but we only implement these for now, because we don't know what other types' serialization looks like,
@@ -32,15 +33,16 @@ struct SosField {
 class Soundevent {
 private:
 	std::string name;
-	int sourceEntityIndex;
+	int sourceEntityIndex = -1;
 	std::map<std::string, SosField> parameters;
-	CPlayerBitVec clients;
+	CRecipientFilter clients;
 
 	SosField* GetField(std::string pszFieldName);
 	void AddOrReplaceField(std::string pszFieldName, const SosField* field);
 
 public:
-	void Emit();
+	Soundevent();
+	int Emit();
 
 	void SetName(std::string name);
 	std::string GetName();

--- a/src/network/soundevents/soundevent.h
+++ b/src/network/soundevents/soundevent.h
@@ -42,7 +42,7 @@ private:
 
 public:
 	Soundevent();
-	int Emit();
+	uint32_t Emit();
 
 	void SetName(std::string name);
 	std::string GetName();

--- a/src/network/soundevents/soundevent.h
+++ b/src/network/soundevents/soundevent.h
@@ -1,0 +1,73 @@
+#ifndef soundevent_h
+#define soundevent_h
+
+#include <string>
+#include <map>
+#include <vector>
+#include <variant.h>
+#include <public/bitvec.h>
+#include <mathlib/vector.h>
+
+#define SOUNDEVENT_NAME_HASH 0x53524332
+#define SOUNDEVENT_PARAM_NAME_HASH 0x31415926
+/*
+reversed from game, there's more type than the following,
+but we only implement these for now, because we don't know what other types' serialization looks like,
+and these should be sufficient in most case
+*/
+enum SosFieldType {
+	SE_Bool = 1,
+	SE_Int = 2,
+	SE_UInt32 = 3,
+	SE_UInt64 = 4,
+	SE_Float = 8,
+	SE_Float3 = 0xA
+};
+
+struct SosField {
+	SosFieldType type;
+	CVariant data;
+};
+
+class Soundevent {
+private:
+	std::string name;
+	int sourceEntityIndex;
+	std::map<std::string, SosField> parameters;
+	CPlayerBitVec clients;
+
+	SosField* GetField(std::string pszFieldName);
+	void AddOrReplaceField(std::string pszFieldName, const SosField* field);
+
+public:
+	void Emit();
+
+	void SetName(std::string name);
+	std::string GetName();
+	void SetSourceEntityIndex(int sourceEntityIndex);
+	int GetSourceEntityIndex();
+
+	void AddClient(int playerid);
+	void RemoveClient(int playerId);
+    void ClearClients();
+    void AddClients();
+	std::vector<int> GetClients();
+
+	bool HasField(std::string pszFieldName);
+	
+	void SetBool(std::string pszFieldName, bool value);
+	bool GetBool(std::string pszFieldName);
+	void SetInt(std::string pszFieldName, int value);
+	int GetInt(std::string pszFieldName);
+	void SetUInt32(std::string pszFieldName, uint32_t value);
+	uint32_t GetUInt32(std::string pszFieldName);
+	void SetUInt64(std::string pszFieldName, uint64_t value);
+	uint64_t GetUInt64(std::string pszFieldName);
+	void SetFloat(std::string pszFieldName, float value);
+	float GetFloat(std::string pszFieldName);
+	void SetFloat3(std::string pszFieldName, Vector& value);
+	Vector GetFloat3(std::string pszFieldName);
+
+};
+
+#endif

--- a/src/scripting/network/soundevent.cpp
+++ b/src/scripting/network/soundevent.cpp
@@ -1,0 +1,146 @@
+#include <scripting/core.h>
+
+#include <network/soundevents/soundevent.h>
+
+LoadScriptingComponent(soundevent, [](PluginObject plugin, EContext* ctx) -> void {
+    ADD_CLASS("SoundEvent");
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SoundEvent", [](FunctionContext* context, ClassData* data) -> void {
+        auto classData = context->GetArgumentOr<ClassData*>(0, nullptr);
+        if (classData) {
+            if (classData->HasData("se_ptr")) {
+                data->SetData("se_ptr", classData->GetData<Soundevent*>("se_ptr"));
+            }
+            else {
+                data->SetData("se_ptr", new Soundevent());
+            }
+        }
+        else {
+            data->SetData("se_ptr", new Soundevent());
+        }
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "~SoundEvent", [](FunctionContext* context, ClassData* data) -> void {
+        if (data->HasData("se_ptr")) {
+            delete data->GetData<Soundevent*>("se_ptr");
+        }
+    });
+     
+    ADD_CLASS_FUNCTION("SoundEvent", "Emit", [](FunctionContext* context, ClassData* data) -> void {
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->Emit());
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetName", [](FunctionContext* context, ClassData* data) -> void {
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetName());
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetName", [](FunctionContext* context, ClassData* data) -> void {
+        std::string name = context->GetArgumentOr<std::string>(0, "");
+        data->GetData<Soundevent*>("se_ptr")->SetName(name);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetSourceEntityIndex", [](FunctionContext* context, ClassData* data) -> void {
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetSourceEntityIndex());
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetSourceEntityIndex", [](FunctionContext* context, ClassData* data) -> void {
+        int index = context->GetArgumentOr<int>(0, -1);
+        data->GetData<Soundevent*>("se_ptr")->SetSourceEntityIndex(index);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "AddClient", [](FunctionContext* context, ClassData* data) -> void {
+        int playerid = context->GetArgumentOr<int>(0, -1);
+        if (playerid == -1) return;
+        data->GetData<Soundevent*>("se_ptr")->AddClient(playerid);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "RemoveClient", [](FunctionContext* context, ClassData* data) -> void {
+        int playerid = context->GetArgumentOr<int>(0, -1);
+        if (playerid == -1) return;
+        data->GetData<Soundevent*>("se_ptr")->RemoveClient(playerid);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "ClearClients", [](FunctionContext* context, ClassData* data) -> void {
+        data->GetData<Soundevent*>("se_ptr")->ClearClients();
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "AddClients", [](FunctionContext* context, ClassData* data) -> void {
+        data->GetData<Soundevent*>("se_ptr")->AddClients();
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetClients", [](FunctionContext* context, ClassData* data) -> void {
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetClients());
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "HasField", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->HasField(field_name));
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetBool", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetBool(field_name));
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetBool", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        bool value = context->GetArgumentOr<bool>(1, false);
+        data->GetData<Soundevent*>("se_ptr")->SetBool(field_name, value);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetInt", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetInt(field_name));
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetInt", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        int value = context->GetArgumentOr<int>(1, 0);
+        data->GetData<Soundevent*>("se_ptr")->SetInt(field_name, value);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetUInt32", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetUInt32(field_name));
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetUInt32", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        uint32_t value = context->GetArgumentOr<uint32_t>(1, 0);
+        data->GetData<Soundevent*>("se_ptr")->SetUInt32(field_name, value);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetUInt64", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetUInt64(field_name));
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetUInt64", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        uint64_t value = context->GetArgumentOr<uint64_t>(1, 0);
+        data->GetData<Soundevent*>("se_ptr")->SetUInt64(field_name, value);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetFloat", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetFloat(field_name));
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetFloat", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        float value = context->GetArgumentOr<float>(1, 0.0f);
+        data->GetData<Soundevent*>("se_ptr")->SetFloat(field_name, value);
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "GetFloat3", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        context->SetReturn(data->GetData<Soundevent*>("se_ptr")->GetFloat3(field_name));
+    });
+
+    ADD_CLASS_FUNCTION("SoundEvent", "SetFloat3", [](FunctionContext* context, ClassData* data) -> void {
+        std::string field_name = context->GetArgumentOr<std::string>(0, "");
+        Vector value = context->GetArgumentOr<Vector>(1, Vector(0.0, 0.0, 0.0));
+        data->GetData<Soundevent*>("se_ptr")->SetFloat3(field_name, value);
+    });
+
+})

--- a/src/scripting/sdk/schema.cpp
+++ b/src/scripting/sdk/schema.cpp
@@ -196,16 +196,18 @@ void SchemaCallback(PluginObject plugin, EContext* ctx) {
             auto controllerPtr = g_pEntitySystem->GetEntityInstance(CEntityIndex(i));
             if (controllerPtr == instance) {
                 sound.AddClient(i - 1);
-                sound.Emit();
+                context->SetReturn(sound.Emit());
             }
             else {
                 CHandle<CEntityInstance> pawnHandle = schema::GetProp<CHandle<CEntityInstance>>(instance, "CCSPlayerController", "m_hPlayerPawn");
                 if (pawnHandle.Get() == instance) {
                     sound.AddClient(i - 1);
-                    sound.Emit();
+                    context->SetReturn(sound.Emit());
                 }
             }
         }
+
+        context->SetReturn(0);
     });
 
     ADD_CLASS_FUNCTION("SDKClass", "EmitSoundFromEntity", [](FunctionContext* context, ClassData* data) -> void {
@@ -222,7 +224,7 @@ void SchemaCallback(PluginObject plugin, EContext* ctx) {
         sound.SetFloat("public.delay", delay);
         sound.AddClients();
         sound.SetSourceEntityIndex(instance->GetEntityIndex().Get());
-        sound.Emit();
+        context->SetReturn(sound.Emit());
     });
 
     ADD_CLASS_FUNCTION("SDKClass", "TakeDamage", [](FunctionContext* context, ClassData* data) -> void {

--- a/src/scripting/sdk/schema.cpp
+++ b/src/scripting/sdk/schema.cpp
@@ -197,16 +197,17 @@ void SchemaCallback(PluginObject plugin, EContext* ctx) {
             if (controllerPtr == instance) {
                 sound.AddClient(i - 1);
                 context->SetReturn(sound.Emit());
+                return;
             }
             else {
                 CHandle<CEntityInstance> pawnHandle = schema::GetProp<CHandle<CEntityInstance>>(instance, "CCSPlayerController", "m_hPlayerPawn");
                 if (pawnHandle.Get() == instance) {
                     sound.AddClient(i - 1);
                     context->SetReturn(sound.Emit());
+                    return;
                 }
             }
         }
-
         context->SetReturn(0);
     });
 

--- a/src/sdk/components/CSingleRecipientFilter.h
+++ b/src/sdk/components/CSingleRecipientFilter.h
@@ -1,4 +1,8 @@
 #include <public/irecipientfilter.h>
+#include <core/entrypoint.h>
+
+#ifndef _recipient_filter_h
+#define _recipient_filter_h
 
 #define INVALID_PLAYER_SLOT_INDEX -1
 #define INVALID_PLAYER_SLOT CPlayerSlot( INVALID_PLAYER_SLOT_INDEX )
@@ -35,10 +39,21 @@ public:
                 AddRecipient(i);
     }
 
+    void RemoveAllPlayers(void)
+    {
+        m_Recipients.ClearAll();
+    }
+
     void AddRecipient(CPlayerSlot slot)
     {
         if (slot.Get() >= 0 && slot.Get() < ABSOLUTE_PLAYER_LIMIT)
             m_Recipients.Set(slot.Get());
+    }
+
+    void RemoveRecipient(CPlayerSlot slot)
+    {
+        if (slot.Get() >= 0 && slot.Get() < ABSOLUTE_PLAYER_LIMIT)
+            m_Recipients.Clear(slot.Get());
     }
 
     int GetRecipientCount()
@@ -78,3 +93,5 @@ public:
             m_Recipients.Set(nRecipientSlot.Get());
     }
 };
+
+#endif

--- a/xmake.lua
+++ b/xmake.lua
@@ -138,6 +138,7 @@ target(PROJECT_NAME.."-CS2")
 
         'src/scripting/network/database.cpp',
         'src/scripting/network/usermessage.cpp',
+        'src/scripting/network/soundevent.cpp',
 
         'src/scripting/player/manager.cpp',
         'src/scripting/player/player.cpp',

--- a/xmake.lua
+++ b/xmake.lua
@@ -116,6 +116,7 @@ target(PROJECT_NAME.."-CS2")
         'src/network/database/DatabaseManager.cpp',
         'src/network/usermessages/usermessage.cpp',
         'src/network/usermessages/usermessages.cpp',
+        'src/network/soundevents/soundevent.cpp',
 
         'src/plugins/manager.cpp',
         'src/plugins/object.cpp',


### PR DESCRIPTION
This PR implement a new soundevent class to directly send netmessage to emit soundevent with custom parameter, solving the issue that the deprecated game function can't properly handle parameters like volume and patch, and remove the dependency of EmitSound signature.